### PR TITLE
Only test META file in author mode

### DIFF
--- a/t/00_use_meta.t
+++ b/t/00_use_meta.t
@@ -1,5 +1,11 @@
+use v6;
+use lib 'lib';
 use Test;
-plan 1;
-use Test::META;
+constant AUTHOR = ?%*ENV<TEST_AUTHOR>; 
 
-meta-ok();
+if AUTHOR { 
+    require Test::META <&meta-ok>;
+    plan 1;
+    meta-ok;
+    done-testing;
+}


### PR DESCRIPTION
Make the test conditional to allow installation without Test::META being installed in a user's Perl6 installation. See comment in the https://github.com/jonathanstowe/Test-META README file.
