### PR TITLE
Remove v from Perl version number

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,5 +1,5 @@
 {
-        "perl" : "v6",
+        "perl" : "6",
 	"name" : "Config::Simple",
         "version" : "*",
         "description" : "A simple module for your configuration file need",


### PR DESCRIPTION
Get rid of a install warning.
