### PR TITLE
Make meta test panda compatible

### DIFF
--- a/t/00_use_meta.t
+++ b/t/00_use_meta.t
@@ -1,11 +1,15 @@
 use v6;
 use lib 'lib';
 use Test;
-constant AUTHOR = ?%*ENV<TEST_AUTHOR>; 
+plan 1;
 
+constant AUTHOR = ?%*ENV<TEST_AUTHOR>; 
 if AUTHOR { 
     require Test::META <&meta-ok>;
-    plan 1;
     meta-ok;
     done-testing;
+}
+else {
+     skip-rest "Skipping author test";
+     exit;
 }


### PR DESCRIPTION
Unfortunately my previous attempt to fix the META test is still not working with current panda install as the test files returns failure for not running any test.
The new version runs sucessfully (by conditionally skipping the test).
I hope this really works, I can't really test it as I don't know how to install a module from a local directory (or from my github fork).
